### PR TITLE
Prints counters at the end of run_examplegen_local

### DIFF
--- a/run_examplegen_local.py
+++ b/run_examplegen_local.py
@@ -45,8 +45,11 @@ def run():
   )
 
   options = pipeline_options.PipelineOptions(runner='DirectRunner',)
+  result = examplegen.run(configuration, options)
 
-  examplegen.run(configuration, options)
+  metrics = result.metrics().query()
+  for counter in metrics['counters']:
+    print(counter)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A user testing the pipeline ran into join misses upon using a
non-absolute path to the audio file in the label CSV. Counters would
have appeared by default in Dataflow, but the local DirectRunner does
not display them unless they are explicitly printed, as is done here.

To check that counters print out properly, this change also adds a
"success" counter of the number of examples generated.