### PR TITLE
Spectrogram front end for Keras

### DIFF
--- a/multispecies_whale_detection/front_end.py
+++ b/multispecies_whale_detection/front_end.py
@@ -1,0 +1,167 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Ops for signal processing that prepares neural network input."""
+import dataclasses
+
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+
+def amplitude_ratio_to_db(x):
+  return 20.0 * tf.math.log(x / 10.0)
+
+
+def db_to_amplitude_ratio(x):
+  return tf.math.pow(10.0, x / 20.0)
+
+
+@dataclasses.dataclass(frozen=True)
+class FrontEndConfig:
+  """Configuration data object for the FrontEnd Keras layer."""
+
+  sample_rate: int = 2000
+  """Sample rate of the input waveform."""
+  frame_seconds: float = 0.1
+  """Duration of STFT frames."""
+  hop_seconds: float = 0.05
+  """Interval between successive STFT frames."""
+  log_stabilizer: float = 1e-6
+  """Used in log((STFT magnitude) + stabilizer) to avoid division by zero."""
+  lower_bound_hz: float = 8.0
+  """Frequency below which the spectrogram should be truncated.
+
+  This is inteded as a way of ignoring low-frequency noise.
+  """
+
+  per_channel_normalization: bool = False
+  """Whether to subtract estimated noise floors from each STFT row.
+
+  This equalizes overall levels and frequency responses and is useful for
+  datasets where these are inconsistent.
+  """
+  noise_floor_percentile: float = 5.0
+  """Percentile of magnitudes in a row which will be deemed the noise floor.
+
+  Only relevant with per_channel_normalization enabled.
+  """
+  smoother_extent_hz: float = 20.0
+  """Size of average pooling filter applied in noise floor estimation.
+
+  Narrowband signals lasting for a large fraction of the context window can have
+  high amplitude at a noise_floor_percentile that is suitable for other bands,
+  resulting in overattenuation in the narrow band with the signal. This averages
+  over nearby bands to mitigate this effect.
+
+  Only relevant with per_channel_normalization enabled.
+  """
+
+
+def spectrogram(
+    waveform: tf.Tensor,
+    sample_rate: tf.Tensor,
+    frame_seconds: float = 0.025,
+    hop_seconds: float = 0.01,
+) -> tf.Tensor:
+  """Computes a linear-frequency-scale magnitude spectrogram.
+
+  This is a thin convenience wrapper of tf.signal.stft. The additions are a) the
+  conversion of STFT frame duration and hop from seconds to samples and b)
+  taking the magnitude of the complex tensor returned by tf.signal.stft.
+
+  Args:
+    waveform: A [..., samples] float32/float64 Tensor of real-valued signals.
+    sample_rate: The number of samples per second.
+    frame_seconds: The duration of a single STFT frame.
+    hop_seconds: The interval between the starts of consecutive STFT frames.
+
+  Returns:
+    Spectrogram of waveform where the frequency scale is linear and the elements
+    are real magnitudes.
+  """
+  frame_length = int(frame_seconds * sample_rate)
+  frame_step = int(hop_seconds * sample_rate)
+  tf.assert_greater(frame_length, 0)
+  tf.assert_greater(frame_step, 0)
+  stft = tf.signal.stft(
+      waveform, frame_length=frame_length, frame_step=frame_step, pad_end=False)
+  return tf.abs(stft)
+
+
+class FrontEnd(tf.keras.layers.Layer):
+  """Converts audio from waveform to spectrogram.
+
+  This layer simplifies building a Keras model that takes a raw waveform as
+  input and passes it to a CNN. It is initialized with a configuration data
+  object, FrontEndConfig, which collects commonly used fixed parameters.
+
+  The frequency scale is always linear. (A future version will add mel frequency
+  scaling.)
+
+  It optionally normalizes by subtracting a per-channel (frequency bin) noise
+  floor, which is estimated as a percentile of the STFT magnitudes in that
+  channel.
+  """
+
+  def __init__(self, config=None):
+    """Initializes this layer.
+
+    Args:
+      config:
+    """
+    super(FrontEnd, self).__init__()
+    if not config:
+      config = FrontEndConfig()
+    self._config = config
+
+  def get_config(self):
+    """Implements Layer.get_config."""
+    config = super().get_config()
+    config.update(dataclasses.asdict(self._config))
+    return config
+
+  def call(self, waveform, training=False):
+    sample_rate = self._config.sample_rate
+    magnitude = spectrogram(
+        waveform,
+        sample_rate=sample_rate,
+        frame_seconds=self._config.frame_seconds,
+        hop_seconds=self._config.hop_seconds)
+    num_frequency_bins = magnitude.shape[-1]
+    hz_per_bin = sample_rate / 2 / num_frequency_bins
+
+    db = amplitude_ratio_to_db(magnitude + self._config.log_stabilizer)
+
+    if self._config.per_channel_normalization:
+      sgram = db
+      smoother_len = int(self._config.smoother_extent_hz / hz_per_bin)
+      if smoother_len > 0:
+        if sgram.shape.rank == 2:
+          smoother_input = tf.expand_dims(sgram, 0)
+        smoothed = tf.squeeze(
+            tf.nn.avg_pool2d(
+                tf.expand_dims(smoother_input, -1), [1, smoother_len], 1,
+                'SAME'), -1)
+        if sgram.shape.rank == 2:
+          smoothed = tf.squeeze(smoothed, 0)
+      else:
+        smoothed = sgram
+      floor = tfp.stats.percentile(
+          smoothed, self._config.noise_floor_percentile, axis=1, keepdims=True)
+      sgram = sgram - floor
+    else:
+      sgram = db
+
+    sgram = sgram[..., int(self._config.lower_bound_hz / hz_per_bin):]
+
+    return sgram

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ setuptools.setup(
         'resampy',
         'soundfile',
         'tensorflow',
+        'tensorflow_probability',
         # not a direct dependency, but beam.io.tfrecordio asks for this to be as
         # "fast as it could be"
         'python-snappy',

--- a/tests/test_front_end.py
+++ b/tests/test_front_end.py
@@ -1,0 +1,76 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+import unittest
+
+from multispecies_whale_detection import front_end
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+
+class TestFrontEnd(unittest.TestCase):
+
+  def test_call_on_noise(self):
+    sample_rate = 2000
+    config = front_end.FrontEndConfig(sample_rate=sample_rate,)
+    num_samples = sample_rate * 5
+    noise_waveform = tf.random.normal([num_samples], 0, 1e-3)
+    layer = front_end.FrontEnd(config)
+
+    spectrogram = layer(noise_waveform)
+
+    self.assertEqual([99, 128], spectrogram.shape)
+
+  def test_call_on_noise_with_normalization(self):
+    tf.random.set_seed(1413.0)  # to avoid flakiness
+
+    sample_rate = 2000
+    config = front_end.FrontEndConfig(
+        sample_rate=sample_rate,
+        per_channel_normalization=True,
+        noise_floor_percentile=5.0,  # 5.0%
+    )
+    num_samples = sample_rate * 1
+    noise_waveform = tf.random.normal([num_samples], 0, 1e-3)
+    layer = front_end.FrontEnd(config)
+
+    spectrogram = layer(noise_waveform)
+
+    # The values are in a sensible dB range.
+    self.assertTrue(tf.math.reduce_all(spectrogram >= -120.0).numpy())
+    self.assertTrue(tf.math.reduce_all(spectrogram <= 120.0).numpy())
+
+    # Running without normalization and shifting the noise floor percentile
+    # across all channels should bring levels roughly into the same range as the
+    # normalized spectrogram.
+    unnormalized_spectrogram = front_end.FrontEnd(
+        dataclasses.replace(config, per_channel_normalization=False))(
+            noise_waveform)
+    floor = tfp.stats.percentile(unnormalized_spectrogram,
+                                 config.noise_floor_percentile)
+    margin_db = 12.0
+    self.assertLess(
+        tf.math.reduce_max(
+            tf.abs((unnormalized_spectrogram - floor) - spectrogram)),
+        margin_db)
+    # Note that the normalization has made a large adjustment in overall level.
+    self.assertGreater(
+        tf.math.reduce_max(
+            tf.abs(unnormalized_spectrogram - spectrogram)),
+        margin_db + 120.0)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/test_front_end.py
+++ b/tests/test_front_end.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import dataclasses
+import json
 import unittest
 
 from multispecies_whale_detection import front_end
@@ -22,29 +23,31 @@ import tensorflow_probability as tfp
 
 class TestFrontEnd(unittest.TestCase):
 
-  def test_call_on_noise(self):
+  def test_spectrogram_layer_on_noise(self):
+    tf.random.set_seed(3141)  # to avoid flakiness
+
     sample_rate = 2000
-    config = front_end.FrontEndConfig(sample_rate=sample_rate,)
+    config = front_end.SpectrogramConfig(sample_rate=sample_rate,)
     num_samples = sample_rate * 5
     noise_waveform = tf.random.normal([num_samples], 0, 1e-3)
-    layer = front_end.FrontEnd(config)
+    layer = front_end.Spectrogram(config)
 
     spectrogram = layer(noise_waveform)
 
     self.assertEqual([99, 128], spectrogram.shape)
 
-  def test_call_on_noise_with_normalization(self):
-    tf.random.set_seed(1413.0)  # to avoid flakiness
+  def test_spectrogram_layer_on_noise_with_normalization(self):
+    tf.random.set_seed(1413)  # to avoid flakiness
 
     sample_rate = 2000
-    config = front_end.FrontEndConfig(
+    normalization=front_end.NoiseFloorConfig(percentile=5.0)
+    config = front_end.SpectrogramConfig(
         sample_rate=sample_rate,
-        per_channel_normalization=True,
-        noise_floor_percentile=5.0,  # 5.0%
+        normalization=normalization,
     )
     num_samples = sample_rate * 1
     noise_waveform = tf.random.normal([num_samples], 0, 1e-3)
-    layer = front_end.FrontEnd(config)
+    layer = front_end.Spectrogram(config)
 
     spectrogram = layer(noise_waveform)
 
@@ -55,11 +58,11 @@ class TestFrontEnd(unittest.TestCase):
     # Running without normalization and shifting the noise floor percentile
     # across all channels should bring levels roughly into the same range as the
     # normalized spectrogram.
-    unnormalized_spectrogram = front_end.FrontEnd(
-        dataclasses.replace(config, per_channel_normalization=False))(
+    unnormalized_spectrogram = front_end.Spectrogram(
+        dataclasses.replace(config, normalization=None))(
             noise_waveform)
     floor = tfp.stats.percentile(unnormalized_spectrogram,
-                                 config.noise_floor_percentile)
+                                 normalization.percentile)
     margin_db = 12.0
     self.assertLess(
         tf.math.reduce_max(
@@ -67,9 +70,38 @@ class TestFrontEnd(unittest.TestCase):
         margin_db)
     # Note that the normalization has made a large adjustment in overall level.
     self.assertGreater(
-        tf.math.reduce_max(
-            tf.abs(unnormalized_spectrogram - spectrogram)),
+        tf.math.reduce_max(tf.abs(unnormalized_spectrogram - spectrogram)),
         margin_db + 120.0)
+
+  def test_spectrogram_config_serialization(self):
+    default_config = front_end.SpectrogramConfig()
+    non_default_config = front_end.SpectrogramConfig(
+        frame_seconds=0.025,
+        hop_seconds=0.0125,
+        normalization=front_end.NoiseFloorConfig(
+            percentile=0.3,
+            smoother_extent_hz=None,
+        ),
+    )
+    assert default_config != non_default_config
+    layer = front_end.Spectrogram(non_default_config)
+    default_layer = front_end.Spectrogram(default_config)
+
+    keras_config = layer.get_config()
+    reloaded_layer = front_end.Spectrogram.from_config(keras_config)
+
+    waveform = tf.random.normal([4000], 0, 1e-3)
+    non_default_output = layer(waveform)
+    default_output = default_layer(waveform)
+    reloaded_output = reloaded_layer(waveform)
+    tolerance = 1e-4
+    # Change from default settings made the output not close to equal, what's
+    # more, made it not the same shape.
+    assert non_default_output.shape != default_output.shape
+    # But the output of the reloaded layer matches the output from before
+    # saving.
+    self.assertLess(
+        tf.math.reduce_max(non_default_output - reloaded_output), tolerance)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The module added in this change wraps the transformation of a raw
waveform to an image input for a convolutional neural network in a Keras
layer. This can enable training end-to-end from the raw waveform to
class probabilities or, alternatively, serve as a module to reliably
apply the same spectrogram settings in preprocessing and inference.

Change-Id: Ic9b51d3c288baf1faddb38ae95762555352dafe9