### PR TITLE
Datasets that extract fixed-duration windows

### DIFF
--- a/multispecies_whale_detection/dataset.py
+++ b/multispecies_whale_detection/dataset.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """tf.data readers and support for audio TFRecord datasets.
 
 In the :py:class:`Features` enumeration, this module formalizes the specific
@@ -22,15 +21,18 @@ It also has helper methods for using the tf.data API to read Examples conforming
 to this specification, like those produced by
 :py:meth:`multispecies_whale_detection.examplegen.pipeline.run`.
 """
+import dataclasses
 import enum
-from typing import Dict, Union
+import functools
+from typing import Dict, Sequence, Optional, Tuple, Union
 
-from dataclasses import dataclass
 import numpy as np
 import tensorflow as tf
 
+DEFAULT_MIN_OVERLAP = 0.1
 
-@dataclass
+
+@dataclasses.dataclass
 class Feature:
   name: str
   spec: Union[tf.io.FixedLenFeature, tf.io.VarLenFeature]
@@ -54,9 +56,29 @@ class Features(enum.Enum):
   ANNOTATION_LABEL = Feature('annotation_label', tf.io.VarLenFeature(tf.string))
 
 
+def _audio_duration(features: Dict[str, tf.Tensor]) -> tf.Tensor:
+  """Returns the duration, in seconds, of the audio in a Features dict."""
+  waveform = features[Features.AUDIO.value.name]
+  sample_rate = tf.cast(features[Features.SAMPLE_RATE.value.name], tf.float32)
+  return tf.cast(tf.shape(waveform)[0], tf.float32) / sample_rate
+
+
 def parse_fn(
     serialized_example: bytes
 ) -> Dict[str, Union[tf.Tensor, tf.sparse.SparseTensor]]:
+  """Parses and converts Tensors for this module's Features.
+
+  This casts the audio_raw_pcm16 feature to float32 and scales it into the range
+  [-1.0, 1.0].
+
+  Args:
+    serialized_example: A serialized tf.train.ExampleProto with the features
+      dict keys declared in the :py:class:Features enum.
+
+  Returns:
+    Tensor-valued dict of features. The keys are those declared in the
+    :py:class:Features enum.
+  """
   features = tf.io.parse_single_example(
       serialized_example, {f.value.name: f.value.spec for f in Features})
   audio_key: str = Features.AUDIO.value.name
@@ -69,4 +91,258 @@ def parse_fn(
 def new(tfrecord_filepattern: str):
   dataset = tf.data.TFRecordDataset(tf.io.gfile.glob(tfrecord_filepattern))
   dataset = dataset.map(parse_fn)
+  return dataset
+
+
+def extract_window(
+    features: Dict[str, tf.Tensor],
+    start_seconds: float,
+    duration_seconds: float,
+    class_names: Sequence[str],
+    min_overlap: float = DEFAULT_MIN_OVERLAP) -> Tuple[tf.Tensor, tf.Tensor]:
+  """Extracts a context window waveform and labels from an example.
+
+  This operates on single examples, not batches.
+
+  The labels are converted from the sparse form in features to a Tensor of shape
+  [num_classes], whose values are indicators of whether an annotation of the
+  corresponding class overlaps the interval [start_seconds, start_seconds +
+  duration_seconds].
+
+  A features dict missing both AUDIO and SAMPLE_RATE is supported for just
+  converting labels to binary indicators pertaining to a given interval. If
+  AUDIO is in the features dict, then SAMPLE_RATE must be also.
+
+  A features dict missing the annotation-related keys is supported for just
+  extracting audio from an unlabeled example, but it is recommended to always
+  provide the ANNOTATION features, even if the values are empty. If any of the
+  ANNOTATION features is provided, all are required.
+
+  Args:
+    features: A dict as returned by :py:meth:`parse_fn`. It conforms to the
+      schema :py:class:`Features` represents.
+    start_seconds: Beginning of the context window to extract, in seconds from
+      the start of the audio in features.
+    duration_seconds: Duration of the context window to extract, in seconds from
+      the start of the audio in features.
+    class_names: Tensor-like of shape [num_classes] (the same shape as the
+      binary class indicators this function returns).
+    min_overlap: Lower bound for duration of overlap between an annotation
+      interval and an extracted window for the window to be considered positive
+      for the class in that annotation's label.
+
+  Returns:
+    Waveform and labels Tensors, where the waveform is a slice of the audio from
+    features and where the labels is a [len(class_names)]-dimensional tensor of
+    float32 indicators of classes on annotations overlapping the time interval
+    of the waveform.
+  """
+  # Waveform
+  if Features.AUDIO.value.name in features:
+    waveform = features[Features.AUDIO.value.name]
+    sample_rate = tf.cast(features[Features.SAMPLE_RATE.value.name], tf.float32)
+    start_sample = tf.cast(tf.math.floor(sample_rate * start_seconds), tf.int32)
+    # Note that a using a fixed duration rather than an unconstrained [begin,
+    # end] avoids flakiness due to float rounding errors.
+    duration_samples = tf.cast(
+        tf.math.floor(sample_rate * duration_seconds), tf.int32)
+    tf.debugging.assert_less_equal(start_sample + duration_samples,
+                                   tf.shape(waveform)[0])
+    context_waveform = waveform[start_sample:start_sample + duration_samples]
+  else:
+    context_waveform = None
+
+  # Labels
+  if Features.ANNOTATION_BEGIN.value.name in features:
+    annotation_begin = tf.sparse.to_dense(
+        features[Features.ANNOTATION_BEGIN.value.name])
+    annotation_end = tf.sparse.to_dense(
+        features[Features.ANNOTATION_END.value.name])
+    annotation_label = tf.sparse.to_dense(
+        features[Features.ANNOTATION_LABEL.value.name])
+
+    # Creates a Boolean indicator for whether [begin, end] overlaps each
+    # annotation interval on the longer segment.
+    end_seconds = start_seconds + duration_seconds
+    overlap_indicator = ((start_seconds <= annotation_end - min_overlap) &
+                         (end_seconds >= annotation_begin + min_overlap))
+
+    # Creates a matrix where rows correspond to annotation intervals overlapping
+    # this context window. Each row has values all equal to the label of the
+    # annotation for that row.
+    classes_present = tf.reshape(
+        tf.boolean_mask(annotation_label, overlap_indicator), [-1, 1])
+    tiled_classes_present = tf.tile(classes_present, [1, len(class_names)])
+    num_classes_present = tf.shape(classes_present)[0]
+    # Creates a same-shaped matrix, where each column is identically equal to
+    # the value in class_names at that columns index.
+    tiled_classes_to_compare = tf.tile([class_names], [num_classes_present, 1])
+    # Compares the above two matrices to get multi-label binary indicators, in
+    # rows attributable to the corresponding annotations.
+    indicators = (tiled_classes_present == tiled_classes_to_compare)
+
+    # Aggregates such that the context window is labeled positive for any
+    # classes that were labels of any overlapping annotation interval.
+    if tf.math.reduce_any(tf.shape(indicators) > 0):
+      labels = tf.cast(tf.reduce_any(indicators, axis=0), tf.float32)
+    else:
+      labels = tf.zeros([len(class_names)])
+  else:
+    labels = tf.zeros([len(class_names)])
+
+  return context_waveform, labels
+
+
+def random_windows(
+    features: Dict[str, tf.Tensor],
+    context_duration_seconds: float,
+    sample_size: int,
+    class_names: Sequence[str],
+    min_overlap=DEFAULT_MIN_OVERLAP) -> Tuple[tf.Tensor, tf.Tensor]:
+  """Extracts labeled context windows with random starts.
+
+  Args:
+    features: Features of an audio clip as returned by :py:meth:parse_fn.
+    context_duration_seconds: Desired duration of extracted windows. All audio
+      tensors returned will have exactly this duration.
+    sample_size: Desired number of windows to extract.
+    class_names: A list of all possible values of ANNOTATION_LABEL, also known
+      as the label vocabulary.
+    min_overlap: Lower bound for duration of overlap between an annotation
+      interval and an extracted window for the window to be considered positive
+      for the class in that annotation's label.
+
+  Returns:
+    Audio tensor of shape [sample_size, audio_duration_samples] and labels
+    tensor of float32 class labels of shape [sample_size, len(class_names)].
+  """
+  extracted_windows = []
+  extracted_labels = []
+  begin_limit = _audio_duration(features) - context_duration_seconds
+  for _ in range(sample_size):
+    begin = tf.random.uniform([], tf.constant(0.0, tf.float32), begin_limit)
+    window, label = extract_window(features, begin, context_duration_seconds,
+                                   class_names, min_overlap)
+    extracted_windows.append(window)
+    extracted_labels.append(label)
+
+  return tf.stack(extracted_windows), tf.stack(extracted_labels)
+
+
+def sliding_windows(
+    features: Dict[str, tf.Tensor],
+    context_duration_seconds: float,
+    hop_seconds: float,
+    class_names: Sequence[str],
+    min_overlap=DEFAULT_MIN_OVERLAP) -> Tuple[tf.Tensor, tf.Tensor]:
+  """Extracts labeled context windows sliding at a fixed period.
+
+  The number of windows extracted depends on the duration of the audio given.
+  All windows that fit within the bounds of the clip will be returned.
+
+  Args:
+    features: Features of an audio clip as returned by :py:meth:parse_fn.
+    context_duration_seconds: Desired duration of extracted windows. All audio
+      tensors returned will have exactly this duration.
+    hop_seconds: The fixed period at which the slice to extract slides over the
+      audio clip.
+    class_names: A list of all possible values of ANNOTATION_LABEL, also known
+      as the label vocabulary.
+    min_overlap: Lower bound for duration of overlap between an annotation
+      interval and an extracted window for the window to be considered positive
+      for the class in that annotation's label.
+
+  Returns:
+    Audio tensor of shape [sample_size, audio_duration_samples] and labels
+    tensor of float32 class labels of shape [sample_size, len(class_names)].
+  """
+  num_hops = 1 + tf.cast(
+      tf.math.floor(
+          (_audio_duration(features) - context_duration_seconds) / hop_seconds),
+      tf.int32)
+  extracted_windows = tf.TensorArray(tf.float32, size=num_hops)
+  extracted_labels = tf.TensorArray(tf.float32, size=num_hops)
+  begin = 0.0
+  index = 0
+  while begin + context_duration_seconds <= _audio_duration(features):
+    window, label = extract_window(features, begin, context_duration_seconds,
+                                   class_names, min_overlap)
+    extracted_windows = extracted_windows.write(index, window)
+    extracted_labels = extracted_labels.write(index, label)
+    begin += hop_seconds
+    index += 1
+  return extracted_windows.stack(), extracted_labels.stack()
+
+
+def new_window_dataset(
+    tfrecord_filepattern: str,
+    context_duration_seconds: float,
+    class_names: Sequence[str],
+    sample_size: Optional[int] = None,
+    hop_seconds: Optional[float] = None,
+    min_overlap=DEFAULT_MIN_OVERLAP,
+) -> tf.data.Dataset:
+  """Parallel tf.data pipeline to extract windows from TFRecords.
+
+  This is intended for initializing a training set when sample_size is not None
+  and a validation or test set when hop_seconds is not None. Exactly one of the
+  two must be None.
+
+  Args:
+    tfrecord_filepattern: Glob pattern matching TFRecord files of serialized
+      tf.train.Examples as produced by examplegen. These represent mono audio
+      clips with sparse labels given by corresponding float endpoints and string
+      labels. batch_size
+    context_duration_seconds: The common duration of the waveforms this Dataset
+      yields.
+    class_names: String values expected in ANNOTATION_LABEL features, the order
+      of which determined class indices in the labels this dataset yields.
+    sample_size: When set, specifies that this number of context windows with
+      random starts should be extracted from each input audio. Mutually
+      exclusive with hop_seconds.
+    hop_seconds: When set, specifies that all context windows sliding over the
+      input audio at this period - that remain in bounds - should be extracted.
+      Mutually exclusive with sample_size.
+    min_overlap: Lower bound on the duration of overlap between an ANNOTATION
+      feature interval and a context window for that context window to count as
+      positive for the ANNOTATION_LABEL.
+
+  Returns:
+    Dataset of individual (context window waveform, label) tuples. All context
+    windows have the same fixed length, determined by context_window_seconds.
+    The labels are 0.0/1.0 indicators of whether an annotated interval for the
+    corresponding class overlaps the context window.
+
+  Raises:
+    ValueError: If both or neither of sample_size and hop_seconds are set.
+  """
+  if (sample_size is None) == (hop_seconds is None):
+    raise ValueError('exactly one of sample_size and hop_seconds should be set')
+  window_fn_args = dict(
+      context_duration_seconds=context_duration_seconds,
+      class_names=class_names,
+      min_overlap=min_overlap,
+  )
+  if sample_size is not None:
+    window_fn_args.update(sample_size=sample_size)
+    window_fn = functools.partial(random_windows, **window_fn_args)
+  else:
+    window_fn_args.update(hop_seconds=hop_seconds)
+    window_fn = functools.partial(sliding_windows, **window_fn_args)
+
+  def shard_fn(filename):
+    dataset = tf.data.TFRecordDataset(filename)
+    dataset = dataset.map(parse_fn)
+    dataset = dataset.map(window_fn)
+    dataset = dataset.unbatch()
+    return dataset
+
+  filenames = tf.io.gfile.glob(tfrecord_filepattern)
+  dataset = tf.data.Dataset.from_tensor_slices(filenames)
+  dataset = dataset.interleave(
+      shard_fn,
+      cycle_length=len(filenames),
+      num_parallel_calls=tf.data.AUTOTUNE,
+      deterministic=False,
+  )
   return dataset

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -178,15 +178,15 @@ class TestDataset(unittest.TestCase):
     }
     # Note that this doubles a test for the case where ANNOTATION features are
     # not provided.
-    start_seconds = 0.5
+    start = 0.5
     window_duration = 0.2
-    begin_sample = int(start_seconds * sample_rate)
+    begin_sample = int(start * sample_rate)
     end_sample = begin_sample + int(window_duration * sample_rate)
     expected_extract = waveform[begin_sample:end_sample]
 
     extract, _ = dataset.extract_window(
         features,
-        start_seconds=start_seconds,
+        start=start,
         duration=window_duration,
         class_names=CLASS_NAMES,
     )
@@ -206,7 +206,7 @@ class TestDataset(unittest.TestCase):
     # not provided.
     _, labels = dataset.extract_window(
         features,
-        start_seconds=0.0,
+        start=0.0,
         duration=3.0,
         class_names=CLASS_NAMES,
         min_overlap=0.1,
@@ -227,7 +227,7 @@ class TestDataset(unittest.TestCase):
 
     _, labels = dataset.extract_window(
         features,
-        start_seconds=1.0,
+        start=1.0,
         duration=1.0,
         class_names=CLASS_NAMES,
         min_overlap=0.1,
@@ -310,7 +310,7 @@ class TestDataset(unittest.TestCase):
     sample_rate = 200
     clip_duration = 10.0
     window_duration = 2.0
-    hop_seconds = window_duration / 2
+    hop = window_duration / 2
     waveform = _sin_waveform(
         frequency_hz=440.0,
         duration=clip_duration,
@@ -332,12 +332,11 @@ class TestDataset(unittest.TestCase):
             tf.sparse.from_dense(['Oo']),
     }
 
-    windowing = dataset.SlidingWindowing(hop_seconds)
+    windowing = dataset.SlidingWindowing(hop)
     windows, labels = windowing.extract_windows(features, window_duration,
                                                 class_names)
 
-    expected_window_count = _window_count(clip_duration, window_duration,
-                                          hop_seconds)
+    expected_window_count = _window_count(clip_duration, window_duration, hop)
     self.assertEqual(
         tf.TensorShape([expected_window_count, window_duration_samples]),
         windows.shape)
@@ -371,7 +370,7 @@ class TestDataset(unittest.TestCase):
 
   def test_new_window_dataset_sliding(self):
     window_duration = 1.0
-    hop_seconds = 0.5
+    hop = 0.5
     class_names = ['Orca', 'Offshore', 'Resident']
     examples = _integration_test_fixture_examples()
     with _temp_tfrecords(examples) as infile:
@@ -380,14 +379,14 @@ class TestDataset(unittest.TestCase):
         window_dataset = dataset.new_window_dataset(
             tfrecord_filepattern=infile.name,
             duration=window_duration,
-            windowing=dataset.SlidingWindowing(hop_seconds),
+            windowing=dataset.SlidingWindowing(hop),
             class_names=class_names,
         ).batch(batch_size)
 
         windows, labels = next(iter(window_dataset))
         example = Example()
         clip_duration = len(example.waveform) / example.sample_rate
-        num_hops = _window_count(clip_duration, window_duration, hop_seconds)
+        num_hops = _window_count(clip_duration, window_duration, hop)
         window_duration_samples = int(window_duration * Example().sample_rate)
         num_outputs = min(batch_size, num_hops)
         self.assertEqual(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,412 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+import datetime
+import math
+import tempfile
+from typing import Iterable
+import unittest
+
+from multispecies_whale_detection import dataset
+from multispecies_whale_detection import examplegen
+import numpy as np
+import tensorflow as tf
+
+CLASS_NAMES = ['Bm', 'Bp', 'Be', 'Mn', 'Eg', 'Ej', 'Oo']
+"""Whale genus / species codes."""
+
+
+def _window_count(clip_duration: float, context_duration: float,
+                  hop: float) -> int:
+  """Returns the number context window hops in bounds of a clip."""
+  return int((clip_duration - context_duration) / hop) + 1
+
+
+def _sin_waveform(frequency_hz: float, duration_seconds: float,
+                  sample_rate: int) -> tf.Tensor:
+  """Returns a sinusoidal waveform with the given shape parameter arguments."""
+  sample_index = tf.range(0, duration_seconds * sample_rate, dtype=tf.float32)
+  return tf.math.sin(2 * math.pi * frequency_hz / sample_rate * sample_index)
+
+
+def _waveform_contains_window(window: tf.Tensor, waveform: tf.Tensor) -> bool:
+  """Tests if an extracted window matches any slice of a given waveform."""
+  # Slide a window of the same duration as the extracted window over the
+  # original waveform and check that there exists a sample offset at which it
+  # matches the extracted window.
+  duration_samples = waveform.shape[0]
+  context_duration_samples = window.shape[0]
+  num_positions = duration_samples - context_duration_samples
+  all_windows = tf.stack(
+      [waveform[i:i + context_duration_samples] for i in range(num_positions)])
+  tiled_extracted_window = tf.tile(
+      tf.expand_dims(window, 0), [num_positions, 1])
+  extracted_matches_row = tf.math.reduce_all(
+      all_windows == tiled_extracted_window, axis=1)
+  return tf.math.reduce_any(extracted_matches_row).numpy()
+
+
+def _temp_tfrecords(
+    examples: Iterable[tf.train.Example]) -> tempfile.NamedTemporaryFile:
+  """Returns a temporary TFRecord file, which serializes the given examples."""
+  file = tempfile.NamedTemporaryFile()
+  with tf.io.TFRecordWriter(file.name) as writer:
+    for example in examples:
+      writer.write(example.SerializeToString())
+  return file
+
+
+@dataclasses.dataclass(frozen=True)
+class Example:
+  """Structured arguments to examplegen.audio_example.
+
+  This is intended to enable more readable assertions by providing fine-grained
+  access to a fixture example populated with default values.
+  """
+  sample_rate: int = 200
+  duration_seconds: float = 10.0
+
+  clip_metadata: examplegen.ClipMetadata = examplegen.ClipMetadata(
+      filename='audio.wav',
+      sample_rate=sample_rate,
+      duration=datetime.timedelta(seconds=duration_seconds),
+      index_in_file=123,
+      start_relative_to_file=datetime.timedelta(seconds=0.0),
+      start_utc=datetime.datetime(2022, 3, 4, 22, 36, 39),
+  )
+
+  waveform: np.ndarray = (_sin_waveform(
+      frequency_hz=440.0,
+      duration_seconds=duration_seconds,
+      sample_rate=sample_rate,
+  ).numpy() * (np.iinfo(np.int16).max - 1)).astype(np.int16)
+
+  channel: int = 0
+
+  annotations: Iterable[examplegen.ClipAnnotation] = dataclasses.field(
+      default_factory=lambda: [
+          examplegen.ClipAnnotation(
+              begin=datetime.timedelta(seconds=3.62),
+              end=datetime.timedelta(seconds=4.1),
+              label='Eg')
+      ])
+
+
+def _integration_test_fixture_examples() -> Iterable[tf.train.Example]:
+  """Returns contents for a TFRecord file read by tests that require one."""
+  fixture = Example()
+  yield examplegen.audio_example(
+      clip_metadata=fixture.clip_metadata,
+      waveform=fixture.waveform,
+      sample_rate=fixture.sample_rate,
+      channel=fixture.channel,
+      annotations=fixture.annotations,
+  )
+
+
+class TestDataset(unittest.TestCase):
+
+  def assertFeaturesMatchFixture(self, features):
+    fixture = Example()
+
+    np.testing.assert_allclose(
+        fixture.waveform, (np.iinfo(np.int16).max - 1) *
+        features[dataset.Features.AUDIO.value.name],
+        atol=2.0)
+    self.assertEqual(fixture.sample_rate,
+                     features[dataset.Features.SAMPLE_RATE.value.name])
+    self.assertEqual(fixture.channel,
+                     features[dataset.Features.CHANNEL.value.name])
+
+    self.assertEqual(fixture.clip_metadata.filename,
+                     features[dataset.Features.FILENAME.value.name])
+    self.assertEqual(
+        fixture.clip_metadata.start_relative_to_file.total_seconds(),
+        features[dataset.Features.START_RELATIVE_TO_FILE.value.name])
+    self.assertEqual(fixture.clip_metadata.start_utc.timestamp(),
+                     features[dataset.Features.START_UTC.value.name])
+
+    annotation = fixture.annotations[0]
+    self.assertEqual(
+        [annotation.begin.total_seconds()],
+        features[dataset.Features.ANNOTATION_BEGIN.value.name].values)
+    self.assertEqual(
+        [annotation.end.total_seconds()],
+        features[dataset.Features.ANNOTATION_END.value.name].values)
+    self.assertEqual(
+        [annotation.label],
+        features[dataset.Features.ANNOTATION_LABEL.value.name].values)
+
+  def test_parse_fn(self):
+    self.assertFeaturesMatchFixture(
+        dataset.parse_fn(
+            next(iter(
+                _integration_test_fixture_examples())).SerializeToString()))
+
+  def test_new(self):
+    examples = _integration_test_fixture_examples()
+    with _temp_tfrecords(examples) as infile:
+      new_dataset = dataset.new(infile.name)
+      features = next(iter(new_dataset))
+    self.assertFeaturesMatchFixture(features)
+
+  def test_extract_window_waveform(self):
+    sample_rate = 2000
+    waveform = _sin_waveform(
+        frequency_hz=440.0,
+        duration_seconds=2.0,
+        sample_rate=sample_rate,
+    )
+    features = {
+        dataset.Features.AUDIO.value.name: waveform,
+        dataset.Features.SAMPLE_RATE.value.name: sample_rate,
+    }
+    # Note that this doubles a test for the case where ANNOTATION features are
+    # not provided.
+    start_seconds = 0.5
+    duration_seconds = 0.2
+    begin_sample = int(start_seconds * sample_rate)
+    end_sample = begin_sample + int(duration_seconds * sample_rate)
+    expected_extract = waveform[begin_sample:end_sample]
+
+    extract, _ = dataset.extract_window(
+        features,
+        start_seconds=start_seconds,
+        duration_seconds=duration_seconds,
+        class_names=CLASS_NAMES,
+    )
+
+    self.assertTrue(tf.reduce_all(expected_extract == extract))
+
+  def test_extract_window_labels(self):
+    features = {
+        dataset.Features.ANNOTATION_BEGIN.value.name:
+            tf.sparse.from_dense([0.5, 2.5, 3.5]),
+        dataset.Features.ANNOTATION_END.value.name:
+            tf.sparse.from_dense([1.1, 3.2, 4.0]),
+        dataset.Features.ANNOTATION_LABEL.value.name:
+            tf.sparse.from_dense(['Oo', 'Mn', 'Ej']),
+    }
+    # Note that this doubles a test for the case where AUDIO features are
+    # not provided.
+    _, labels = dataset.extract_window(
+        features,
+        start_seconds=0.0,
+        duration_seconds=3.0,
+        class_names=CLASS_NAMES,
+        min_overlap=0.1,
+    )
+
+    self.assertEqual([len(CLASS_NAMES)], labels.shape)
+    self.assertEqual(['Mn', 'Oo'], list(tf.boolean_mask(CLASS_NAMES, labels)))
+
+  def test_extract_window_label_overlap_too_short(self):
+    features = {
+        dataset.Features.ANNOTATION_BEGIN.value.name:
+            tf.sparse.from_dense([0.0]),
+        dataset.Features.ANNOTATION_END.value.name:
+            tf.sparse.from_dense([1.05]),
+        dataset.Features.ANNOTATION_LABEL.value.name:
+            tf.sparse.from_dense(['Bm']),
+    }
+
+    _, labels = dataset.extract_window(
+        features,
+        start_seconds=1.0,
+        duration_seconds=1.0,
+        class_names=CLASS_NAMES,
+        min_overlap=0.1,
+    )
+
+    self.assertEqual([len(CLASS_NAMES)], labels.shape)
+    self.assertTrue(tf.math.reduce_all(labels == 0.0))
+
+  def test_single_random_window(self):
+    sample_rate = 200
+    # This will extract a single window from a clip slightly longer than the
+    # extracted window, so that a label interval in the middle is guaranteed to
+    # overlap.
+    context_duration_seconds = 1.0
+    duration_seconds = (context_duration_seconds + 0.1)
+    waveform = _sin_waveform(
+        frequency_hz=440.0,
+        duration_seconds=duration_seconds,
+        sample_rate=sample_rate,
+    )
+    sample_size = 1
+    class_names = ['Bm', 'Eg']
+    features = {
+        dataset.Features.AUDIO.value.name:
+            waveform,
+        dataset.Features.SAMPLE_RATE.value.name:
+            sample_rate,
+        dataset.Features.ANNOTATION_BEGIN.value.name:
+            tf.sparse.from_dense([0.5]),
+        dataset.Features.ANNOTATION_END.value.name:
+            tf.sparse.from_dense([0.6]),
+        dataset.Features.ANNOTATION_LABEL.value.name:
+            tf.sparse.from_dense(['Bm']),
+    }
+
+    windows, labels = dataset.random_windows(
+        features,
+        context_duration_seconds,
+        sample_size=sample_size,
+        class_names=class_names,
+    )
+
+    context_duration_samples = int(sample_rate * context_duration_seconds)
+    self.assertEqual(
+        tf.TensorShape([sample_size, context_duration_samples]), windows.shape)
+    self.assertEqual(
+        tf.TensorShape([sample_size, len(class_names)]), labels.shape)
+    self.assertTrue(tf.math.reduce_all([[1.0, 0.0]] == labels))
+    self.assertTrue(_waveform_contains_window(windows[0], waveform))
+
+  def test_random_windows_count(self):
+    sample_size = 3
+    sample_rate = 200
+    context_duration_seconds = 1.0
+    waveform = _sin_waveform(
+        frequency_hz=440.0,
+        duration_seconds=2.0,
+        sample_rate=sample_rate,
+    )
+    features = {
+        dataset.Features.AUDIO.value.name: waveform,
+        dataset.Features.SAMPLE_RATE.value.name: sample_rate,
+    }
+    class_names = ['Oo']
+
+    windows, labels = dataset.random_windows(
+        features,
+        context_duration_seconds=1.0,
+        sample_size=sample_size,
+        class_names=class_names,
+    )
+
+    context_duration_samples = int(context_duration_seconds * sample_rate)
+    self.assertEqual(
+        tf.TensorShape([sample_size, context_duration_samples]), windows.shape)
+    self.assertEqual(
+        tf.TensorShape([sample_size, len(class_names)]), labels.shape)
+
+  def test_sliding_windows(self):
+    sample_rate = 200
+    duration_seconds = 10.0
+    context_duration_seconds = 2.0
+    hop_seconds = context_duration_seconds / 2
+    waveform = _sin_waveform(
+        frequency_hz=440.0,
+        duration_seconds=duration_seconds,
+        sample_rate=sample_rate,
+    )
+    context_duration_samples = int(sample_rate * context_duration_seconds)
+    # Label that intersects windows[1] and windows[2].
+    class_names = ['Oo']
+    features = {
+        dataset.Features.AUDIO.value.name:
+            waveform,
+        dataset.Features.SAMPLE_RATE.value.name:
+            sample_rate,
+        dataset.Features.ANNOTATION_BEGIN.value.name:
+            tf.sparse.from_dense([2.25]),
+        dataset.Features.ANNOTATION_END.value.name:
+            tf.sparse.from_dense([2.75]),
+        dataset.Features.ANNOTATION_LABEL.value.name:
+            tf.sparse.from_dense(['Oo']),
+    }
+
+    windows, labels = dataset.sliding_windows(features,
+                                              context_duration_seconds,
+                                              hop_seconds, class_names)
+
+    expected_window_count = _window_count(duration_seconds,
+                                          context_duration_seconds, hop_seconds)
+    self.assertEqual(
+        tf.TensorShape([expected_window_count, context_duration_samples]),
+        windows.shape)
+    self.assertEqual(
+        tf.TensorShape([expected_window_count,
+                        len(class_names)]), labels.shape)
+
+  def test_new_window_dataset_random(self):
+    context_duration_seconds = 2.0
+    sample_size = 3
+    class_names = ['Orca', 'Offshore', 'Resident']
+    examples = _integration_test_fixture_examples()
+    with _temp_tfrecords(examples) as infile:
+      for batch_size in [2, 4]:
+
+        window_dataset = dataset.new_window_dataset(
+            tfrecord_filepattern=infile.name,
+            context_duration_seconds=context_duration_seconds,
+            class_names=class_names,
+            sample_size=sample_size,
+        ).batch(batch_size)
+
+        windows, labels = next(iter(window_dataset))
+        context_duration_samples = int(context_duration_seconds *
+                                       Example().sample_rate)
+        num_outputs = min(batch_size, sample_size)
+        self.assertEqual(
+            tf.TensorShape([num_outputs, context_duration_samples]),
+            windows.shape)
+        self.assertEqual(
+            tf.TensorShape([num_outputs, len(class_names)]), labels.shape)
+
+  def test_new_window_dataset_sliding(self):
+    context_duration_seconds = 1.0
+    hop_seconds = 0.5
+    class_names = ['Orca', 'Offshore', 'Resident']
+    examples = _integration_test_fixture_examples()
+    with _temp_tfrecords(examples) as infile:
+
+      for batch_size in [2, 128]:
+        window_dataset = dataset.new_window_dataset(
+            tfrecord_filepattern=infile.name,
+            context_duration_seconds=context_duration_seconds,
+            class_names=class_names,
+            hop_seconds=hop_seconds,
+        ).batch(batch_size)
+
+        windows, labels = next(iter(window_dataset))
+        example = Example()
+        clip_duration_seconds = len(example.waveform) / example.sample_rate
+        num_hops = _window_count(clip_duration_seconds,
+                                 context_duration_seconds, hop_seconds)
+        context_duration_samples = int(context_duration_seconds *
+                                       Example().sample_rate)
+        num_outputs = min(batch_size, num_hops)
+        self.assertEqual(
+            tf.TensorShape([num_outputs, context_duration_samples]),
+            windows.shape)
+        self.assertEqual(
+            tf.TensorShape([num_outputs, len(class_names)]), labels.shape)
+
+  def test_new_window_dataset_ambiguous(self):
+    # sample_size and hop_seconds both set raises ValueError
+    with self.assertRaises(ValueError):
+      _ = dataset.new_window_dataset(
+          tfrecord_filepattern='',
+          context_duration_seconds=1.0,
+          class_names=['A'],
+          sample_size=3,
+          hop_seconds=1.0,
+      )
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
This commit adds standalone functions that extract random or sliding
context windows of a common duration from features parsed from
tf.train.Examples produced by examplegen.

It also includes an initialization method, new_window_dataset, that
provides a similified API for constructing context-window-level traning
and validation sets.

Finally, it adds unit tests for all methods in the dataset module.

Change-Id: I5c6abd668ded92d8004d9f0dd332d394d33bf9d5