### PR TITLE
Fixes broken tests

### DIFF
--- a/multispecies_whale_detection/examplegen.py
+++ b/multispecies_whale_detection/examplegen.py
@@ -212,10 +212,11 @@ class FileAnnotation(Annotation):
         self.end - clip_metadata.start_relative_to_file,
         clip_metadata,
     )
-    if not endpoints:
+    if endpoints:
+      begin, end = endpoints
+      return ClipAnnotation(begin=begin, end=end, label=self.label)
+    else:
       return None
-    begin, end = endpoints
-    return ClipAnnotation(begin=begin, end=end, label=self.label)
 
 
 @dataclass

--- a/multispecies_whale_detection/examplegen.py
+++ b/multispecies_whale_detection/examplegen.py
@@ -207,11 +207,14 @@ class FileAnnotation(Annotation):
     Returns:
       An annotation relative to the given clip or None if there is no overlap.
     """
-    begin, end = _restrict_to_clip(
+    endpoints = _restrict_to_clip(
         self.begin - clip_metadata.start_relative_to_file,
         self.end - clip_metadata.start_relative_to_file,
         clip_metadata,
     )
+    if not endpoints:
+      return None
+    begin, end = endpoints
     return ClipAnnotation(begin=begin, end=end, label=self.label)
 
 
@@ -244,12 +247,16 @@ class UTCAnnotation(Annotation):
     Raises:
       ValueError if clip_metadata.start_utc is None.
     """
-    begin, end = _restrict_to_clip(
+    endpoints = _restrict_to_clip(
         self.begin - clip_metadata.start_utc,
         self.end - clip_metadata.start_utc,
         clip_metadata,
     )
-    return ClipAnnotation(begin=begin, end=end, label=self.label)
+    if endpoints:
+      begin, end = endpoints
+      return ClipAnnotation(begin=begin, end=end, label=self.label)
+    else:
+      return None
 
 
 # Type of the values for the CoGroupByKey (filename) done by this pipeline.

--- a/tests/test_examplegen.py
+++ b/tests/test_examplegen.py
@@ -22,8 +22,8 @@ from multispecies_whale_detection import examplegen
 
 
 def relative_endpoints_to_file_annotation_fixture(
-    begin_seconds: float, end_seconds: float
-) -> Optional[Tuple[datetime.timedelta, datetime.timedelta]]:
+    begin_seconds: float,
+    end_seconds: float) -> Optional[examplegen.ClipAnnotation]:
   """Template testing FileAnnotations relative to a fixture clip.
 
   The fixture clip covers the time interval [10s, 20s] relative to the file.
@@ -33,7 +33,8 @@ def relative_endpoints_to_file_annotation_fixture(
     end_seconds: Ending of the test FileAnnotation relative to the file.
 
   Returns:
-    Endpoints relative to the clip.
+    Annotation over the restriction of the given time interval to the fixture
+    clip or None if they don't overlap.
   """
   start_relative_to_file = datetime.timedelta(seconds=20)
 
@@ -50,16 +51,12 @@ def relative_endpoints_to_file_annotation_fixture(
       end=datetime.timedelta(seconds=end_seconds),
       label='Oo',
   )
-  clip_annotation = annotation.make_relative(clip_metadata)
-  if clip_annotation:
-    return clip_annotation.begin, clip_annotation.end
-  else:
-    return None
+  return annotation.make_relative(clip_metadata)
 
 
 def relative_endpoints_to_utc_annotation_fixture(
-    begin_seconds: float, end_seconds: float
-) -> Optional[Tuple[datetime.timedelta, datetime.timedelta]]:
+    begin_seconds: float,
+    end_seconds: float) -> Optional[examplegen.ClipAnnotation]:
   """Template testing UTCAnnotations relative to a fixture clip.
 
   This is a modification of the FileAnnotation version to convert identical
@@ -73,7 +70,8 @@ def relative_endpoints_to_utc_annotation_fixture(
     end_seconds: Ending of the test UTCAnnotation relative to the file.
 
   Returns:
-    Endpoints relative to the clip.
+    Annotation over the restriction of the given time interval to the fixture
+    clip or None if they don't overlap.
   """
   file_start_utc = datetime.datetime(2012, 2, 3, 11, 45, 20, tzinfo=tz.UTC)
   start_relative_to_file = datetime.timedelta(seconds=20)
@@ -91,11 +89,7 @@ def relative_endpoints_to_utc_annotation_fixture(
       end=file_start_utc + datetime.timedelta(seconds=end_seconds),
       label='Oo',
   )
-  clip_annotation = annotation.make_relative(clip_metadata)
-  if clip_annotation:
-    return clip_annotation.begin, clip_annotation.end
-  else:
-    return None
+  return annotation.make_relative(clip_metadata)
 
 
 class TestAnnotations(unittest.TestCase):
@@ -158,9 +152,9 @@ class TestAnnotations(unittest.TestCase):
     self.assertEqual(annotation, coder.decode(encoded))
 
   def test_file_annotation_relative_endpoints_within_clip(self):
-    begin, end = relative_endpoints_to_file_annotation_fixture(22, 23.2)
-    self.assertEqual(datetime.timedelta(seconds=2), begin)
-    self.assertEqual(datetime.timedelta(seconds=3.2), end)
+    clip_annotation = relative_endpoints_to_file_annotation_fixture(22, 23.2)
+    self.assertEqual(datetime.timedelta(seconds=2), clip_annotation.begin)
+    self.assertEqual(datetime.timedelta(seconds=3.2), clip_annotation.end)
 
   def test_file_annotation_relative_endpoints_before_clip(self):
     self.assertIsNone(relative_endpoints_to_file_annotation_fixture(1.5, 2.5))
@@ -169,9 +163,9 @@ class TestAnnotations(unittest.TestCase):
     self.assertIsNone(relative_endpoints_to_file_annotation_fixture(42, 45))
 
   def test_file_annotation_relative_endpoints_overlap_begin(self):
-    begin, end = relative_endpoints_to_file_annotation_fixture(19.5, 22.1)
-    self.assertEqual(datetime.timedelta(seconds=0), begin)
-    self.assertEqual(datetime.timedelta(seconds=2.1), end)
+    clip_annotation = relative_endpoints_to_file_annotation_fixture(19.5, 22.1)
+    self.assertEqual(datetime.timedelta(seconds=0), clip_annotation.begin)
+    self.assertEqual(datetime.timedelta(seconds=2.1), clip_annotation.end)
 
   def test_round_trip_utc_annotation(self):
     begin = datetime.datetime(2012, 2, 3, 11, 45, 15, tzinfo=tz.UTC)
@@ -184,9 +178,9 @@ class TestAnnotations(unittest.TestCase):
     self.assertEqual(annotation, coder.decode(encoded))
 
   def test_utc_annotation_relative_endpoints_within_clip(self):
-    begin, end = relative_endpoints_to_utc_annotation_fixture(22, 23.2)
-    self.assertEqual(datetime.timedelta(seconds=2), begin)
-    self.assertEqual(datetime.timedelta(seconds=3.2), end)
+    clip_annotation = relative_endpoints_to_utc_annotation_fixture(22, 23.2)
+    self.assertEqual(datetime.timedelta(seconds=2), clip_annotation.begin)
+    self.assertEqual(datetime.timedelta(seconds=3.2), clip_annotation.end)
 
   def test_utc_annotation_relative_endpoints_before_clip(self):
     self.assertIsNone(relative_endpoints_to_utc_annotation_fixture(1.5, 2.5))
@@ -195,9 +189,9 @@ class TestAnnotations(unittest.TestCase):
     self.assertIsNone(relative_endpoints_to_utc_annotation_fixture(42, 45))
 
   def test_utc_annotation_relative_endpoints_overlap_begin(self):
-    begin, end = relative_endpoints_to_utc_annotation_fixture(19.5, 22.1)
-    self.assertEqual(datetime.timedelta(seconds=0), begin)
-    self.assertEqual(datetime.timedelta(seconds=2.1), end)
+    clip_annotation = relative_endpoints_to_utc_annotation_fixture(19.5, 22.1)
+    self.assertEqual(datetime.timedelta(seconds=0), clip_annotation.begin)
+    self.assertEqual(datetime.timedelta(seconds=2.1), clip_annotation.end)
 
 
 if __name__ == '__main__':

--- a/tests/test_examplegen.py
+++ b/tests/test_examplegen.py
@@ -33,8 +33,7 @@ def relative_endpoints_to_file_annotation_fixture(
     end_seconds: Ending of the test FileAnnotation relative to the file.
 
   Returns:
-    Endpoints relative to the clip, as
-    :py::meth:`examplegen.FileAnnotation.relative_endpoints`.
+    Endpoints relative to the clip.
   """
   start_relative_to_file = datetime.timedelta(seconds=20)
 
@@ -51,7 +50,11 @@ def relative_endpoints_to_file_annotation_fixture(
       end=datetime.timedelta(seconds=end_seconds),
       label='Oo',
   )
-  return annotation.relative_endpoints(clip_metadata)
+  clip_annotation = annotation.make_relative(clip_metadata)
+  if clip_annotation:
+    return clip_annotation.begin, clip_annotation.end
+  else:
+    return None
 
 
 def relative_endpoints_to_utc_annotation_fixture(
@@ -70,8 +73,7 @@ def relative_endpoints_to_utc_annotation_fixture(
     end_seconds: Ending of the test UTCAnnotation relative to the file.
 
   Returns:
-    Endpoints relative to the clip, as
-    :py::meth:`examplegen.FileAnnotation.relative_endpoints`.
+    Endpoints relative to the clip.
   """
   file_start_utc = datetime.datetime(2012, 2, 3, 11, 45, 20, tzinfo=tz.UTC)
   start_relative_to_file = datetime.timedelta(seconds=20)
@@ -89,7 +91,11 @@ def relative_endpoints_to_utc_annotation_fixture(
       end=file_start_utc + datetime.timedelta(seconds=end_seconds),
       label='Oo',
   )
-  return annotation.relative_endpoints(clip_metadata)
+  clip_annotation = annotation.make_relative(clip_metadata)
+  if clip_annotation:
+    return clip_annotation.begin, clip_annotation.end
+  else:
+    return None
 
 
 class TestAnnotations(unittest.TestCase):

--- a/tests/test_xwav.py
+++ b/tests/test_xwav.py
@@ -359,10 +359,6 @@ class TestXwav(unittest.TestCase):
     )
 
     write_output.seek(0)
-    with open('debug', 'wb') as outfile:
-      shutil.copyfileobj(write_output, outfile)
-
-    write_output.seek(0)
     rereader = xwav.Reader(write_output)
     self.reader_reads_two_chunk_fixture_template(rereader)
 


### PR DESCRIPTION
This change makes needed updates that an examplegen refactoring that
allowed None returns for labels omitted. It also removes a binary dump
in test_xwav that was never intended to be committed.