### PR TITLE
Validates FrontEnd configs early.

### DIFF
--- a/multispecies_whale_detection/front_end.py
+++ b/multispecies_whale_detection/front_end.py
@@ -245,18 +245,15 @@ class Spectrogram(tf.keras.layers.Layer):
 
     # Validate during initialization that correct configuration was passed.
     frequency_scaling = self._config.frequency_scaling
-    if not frequency_scaling:
-      pass
-    elif isinstance(frequency_scaling, (MelScalingConfig, CropFrequencyConfig)):
+    if isinstance(frequency_scaling, (type(None), MelScalingConfig,
+        CropFrequencyConfig)):
       pass
     else:
       raise TypeError(
           f'unknown frequency scaling type {type(frequency_scaling)}')
 
     normalization = self._config.normalization
-    if not normalization:
-      pass
-    elif isinstance(normalization, NoiseFloorConfig):
+    if isinstance(normalization, (type(None), NoiseFloorConfig)):
       pass
     else:
       raise TypeError(f'unknown normalization type {type(normalization)}')

--- a/multispecies_whale_detection/front_end.py
+++ b/multispecies_whale_detection/front_end.py
@@ -32,6 +32,10 @@ def db_to_amplitude_ratio(x):
   return tf.math.pow(10.0, x / 20.0)
 
 
+def db_to_power_ratio(x):
+  return tf.math.pow(10.0, x / 10.0)
+
+
 @dataclasses.dataclass(frozen=True)
 class CropFrequencyConfig:
   """Frequency "scaling" that ignores a range.
@@ -234,10 +238,28 @@ class Spectrogram(tf.keras.layers.Layer):
         spectrogram to different time scales, distances to source, level
         variability across endpoints, etc.
     """
-    super(Spectrogram, self).__init__()
+    super().__init__()
     if not config:
       config = SpectrogramConfig()
     self._config = config
+
+    # Validate during initialization that correct configuration was passed.
+    frequency_scaling = self._config.frequency_scaling
+    if not frequency_scaling:
+      pass
+    elif isinstance(frequency_scaling, (MelScalingConfig, CropFrequencyConfig)):
+      pass
+    else:
+      raise TypeError(
+          f'unknown frequency scaling type {type(frequency_scaling)}')
+
+    normalization = self._config.normalization
+    if not normalization:
+      pass
+    elif isinstance(normalization, NoiseFloorConfig):
+      pass
+    else:
+      raise TypeError(f'unknown normalization type {type(normalization)}')
 
   def call(self, waveform, training=False):
     sample_rate = self._config.sample_rate

--- a/multispecies_whale_detection/front_end.py
+++ b/multispecies_whale_detection/front_end.py
@@ -245,18 +245,11 @@ class Spectrogram(tf.keras.layers.Layer):
 
     # Validate during initialization that correct configuration was passed.
     frequency_scaling = self._config.frequency_scaling
-    if isinstance(frequency_scaling, (type(None), MelScalingConfig,
-        CropFrequencyConfig)):
-      pass
-    else:
-      raise TypeError(
-          f'unknown frequency scaling type {type(frequency_scaling)}')
-
+    assert isinstance(frequency_scaling, (type(None), MelScalingConfig,
+        CropFrequencyConfig)), f'unknown frequency scaling type {type(frequency_scaling)}'
     normalization = self._config.normalization
-    if isinstance(normalization, (type(None), NoiseFloorConfig)):
-      pass
-    else:
-      raise TypeError(f'unknown normalization type {type(normalization)}')
+    assert isinstance(normalization, (type(None),
+        NoiseFloorConfig)), f'unknown normalization type {type(normalization)}'
 
   def call(self, waveform, training=False):
     sample_rate = self._config.sample_rate

--- a/tests/test_front_end.py
+++ b/tests/test_front_end.py
@@ -175,13 +175,13 @@ class TestFrontEnd(unittest.TestCase):
 class TestSpectrogram(unittest.TestCase):
 
   def test_bad_config(self):
-    with self.assertRaises(TypeError):
+    with self.assertRaises(AssertionError):
       # Wrong: NoiseFloorConfig as FrequencyScalingConfig
       config = front_end.SpectrogramConfig(frequency_scaling=front_end.NoiseFloorConfig())
       front_end.Spectrogram(config)
-    with self.assertRaises(TypeError):
+    with self.assertRaises(AssertionError):
       # Wrong: FrequencyScalingConfig as NoiseFloorConfig
-      config = front_end.SpectrogramConfig(noise_floor_config=front_end.MelScalingConfig())
+      config = front_end.SpectrogramConfig(normalization=front_end.MelScalingConfig())
       front_end.Spectrogram(config)
 
     # Make sure default config is correct.

--- a/tests/test_front_end.py
+++ b/tests/test_front_end.py
@@ -172,5 +172,21 @@ class TestFrontEnd(unittest.TestCase):
         tf.math.reduce_max(non_default_output - reloaded_output), tolerance)
 
 
+class TestSpectrogram(unittest.TestCase):
+
+  def test_bad_config(self):
+    with self.assertRaises(TypeError):
+      # Wrong: NoiseFloorConfig as FrequencyScalingConfig
+      config = front_end.SpectrogramConfig(frequency_scaling=front_end.NoiseFloorConfig())
+      front_end.Spectrogram(config)
+    with self.assertRaises(TypeError):
+      # Wrong: FrequencyScalingConfig as NoiseFloorConfig
+      config = front_end.SpectrogramConfig(noise_floor_config=front_end.MelScalingConfig())
+      front_end.Spectrogram(config)
+
+    # Make sure default config is correct.
+    front_end.Spectrogram(front_end.SpectrogramConfig())
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Validate FrontEnd configs on init, so we do not need to wait to call the frontend to realize the config is incorrect.
Add db_to_power_ratio.
In py3, `super(Spectrogram, self).__init__()` can be shortened to `super().__init__()`

Tested by pulling the frontend to a separate model.

Small PR to test how this works (I haven't used GitHub in a while). Please feel free to leave feedback in the review.